### PR TITLE
drop sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
 - "2.2"
-sudo: false
 cache: bundler
 env:
 - FS_INTERFACE=thin


### PR DESCRIPTION
trying to get rid of `sudo: false` in the org per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration